### PR TITLE
libstagefright: fix ScreenRecord abort issue.

### DIFF
--- a/media/libstagefright/MediaBuffer.cpp
+++ b/media/libstagefright/MediaBuffer.cpp
@@ -135,6 +135,7 @@ size_t MediaBuffer::range_length() const {
 void MediaBuffer::set_range(size_t offset, size_t length) {
     if ((mGraphicBuffer == NULL) && (offset + length > mSize)) {
         ALOGE("offset = %zu, length = %zu, mSize = %zu", offset, length, mSize);
+	offset = 0;
     }
     CHECK((mGraphicBuffer != NULL) || (offset + length <= mSize));
 


### PR DESCRIPTION
Set offset to 0, so we can prevent crashes with screenrecord.
Needed on various devices, like OMAP4 based ones. (Galaxy Nexus)

Change-Id: Iad8c807fcdac03a54fddff838274961c87eec340