### PR TITLE
frameworks/av: add old MediaBufferGroup::acquire signature for WVM

### DIFF
--- a/include/media/stagefright/MediaBufferGroup.h
+++ b/include/media/stagefright/MediaBufferGroup.h
@@ -33,13 +33,17 @@ public:
     ~MediaBufferGroup();
 
     void add_buffer(MediaBuffer *buffer);
-
     // If nonBlocking is false, it blocks until a buffer is available and
     // passes it to the caller in *buffer, while returning OK.
     // The returned buffer will have a reference count of 1.
     // If nonBlocking is true and a buffer is not immediately available,
     // buffer is set to NULL and it returns WOULD_BLOCK.
+#ifdef USES_LEGACY_ACQUIRE_WVM
+    status_t acquire_buffer(MediaBuffer **out);
+    status_t acquire_buffer(MediaBuffer **buffer, bool nonBlocking);
+#else
     status_t acquire_buffer(MediaBuffer **buffer, bool nonBlocking = false);
+#endif
 
 protected:
     virtual void signalBufferReturned(MediaBuffer *buffer);

--- a/media/libstagefright/Android.mk
+++ b/media/libstagefright/Android.mk
@@ -103,6 +103,10 @@ ifeq ($(TARGET_BOARD_PLATFORM),omap4)
 LOCAL_CFLAGS := -DBOARD_CANT_REALLOCATE_OMX_BUFFERS
 endif
 
+ifeq ($(BOARD_USES_LEGACY_ACQUIRE_WVM),true)
+LOCAL_CFLAGS := -DUSES_LEGACY_ACQUIRE_WVM
+endif
+
 LOCAL_STATIC_LIBRARIES := \
         libstagefright_color_conversion \
         libstagefright_aacenc \

--- a/media/libstagefright/MediaBufferGroup.cpp
+++ b/media/libstagefright/MediaBufferGroup.cpp
@@ -55,9 +55,15 @@ void MediaBufferGroup::add_buffer(MediaBuffer *buffer) {
     mLastBuffer = buffer;
 }
 
+#ifdef USES_LEGACY_ACQUIRE_WVM
 status_t MediaBufferGroup::acquire_buffer(
-        MediaBuffer **out, bool nonBlocking) {
-    Mutex::Autolock autoLock(mLock);
+    MediaBuffer **out) {
+        return this->acquire_buffer(out, false);
+    }
+#endif
+status_t MediaBufferGroup::acquire_buffer(
+    MediaBuffer **out, bool nonBlocking) {
+        Mutex::Autolock autoLock(mLock);
 
     for (;;) {
         for (MediaBuffer *buffer = mFirstBuffer;


### PR DESCRIPTION
Needed by libwvm.so from Android 4.2 for the Asus Tegra3

PS2: Clean this up a bit.
PS3: Set with flag BOARD_USES_LEGACY_ACQUIRE_WVM := true
PS4: Getting formatting correct

Change-Id: I1985c2eea78febac078affdc18dd643fe58ede62
